### PR TITLE
Fix moments media rendering and mobile layout issues

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -357,6 +357,12 @@ a.btn {
         h3 {
           font-size: 20px;
         }
+
+        a {
+          font-size: 20px;
+          line-height: 1.4;
+          overflow-wrap: anywhere;
+        }
       }
     }
   }
@@ -375,21 +381,17 @@ a.btn {
     z-index: 2;
     position: absolute;
   }
-
-  .footer {
-    display: none;
-  }
 }
 
 .markdown-body {
   ul {
     list-style: disc;
   }
-  
+
   ol {
     list-style: decimal;
   }
-  
+
   h1, h2, h3, h4, h5, h6 {
     border: none !important;
   }

--- a/src/moments.html
+++ b/src/moments.html
@@ -20,6 +20,31 @@
             <img class="h-12 w-12 rounded-full" th:src="${moment.owner.avatar}" th:alt="${moment.owner.displayName}" />
             <div class="ml-5 flex-1">
               <div th:utext="${content.html}" class="markdown-body !text-sm !text-gray-500"></div>
+              <div th:if="${not #lists.isEmpty(content.medium)}" class="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <th:block th:each="momentItem : ${content.medium}">
+                  <img
+                    th:if="${momentItem.type.name == 'PHOTO'}"
+                    th:src="${momentItem.url}"
+                    th:alt="${moment.owner.displayName}"
+                    class="w-full rounded-lg border border-gray-200"
+                    loading="lazy"
+                  />
+                  <video
+                    th:if="${momentItem.type.name == 'VIDEO'}"
+                    th:src="${momentItem.url}"
+                    class="w-full rounded-lg border border-gray-200"
+                    controls
+                    preload="metadata"
+                  ></video>
+                  <audio
+                    th:if="${momentItem.type.name == 'AUDIO'}"
+                    th:src="${momentItem.url}"
+                    class="w-full"
+                    controls
+                    preload="metadata"
+                  ></audio>
+                </th:block>
+              </div>
               <div class="mt-3 flex items-center gap-4">
                 <div
                   class="journal-likes inline-flex cursor-pointer items-center text-sm text-gray-400 transition-all hover:text-red-700"


### PR DESCRIPTION
## What changed

- Render media entries from `content.medium` on the moments page, including photos, videos, and audio.
- Keep the configured Halo footer visible on mobile layouts.
- Apply the mobile title size to the sidebar title link as well, so long site titles do not keep the desktop `2rem` size on small screens.

## Issues verified

Fixes #21
Fixes #16
Fixes #13

## Not fixed in this PR

- #25 could not be reproduced: the local article page renders the comment widget container and initialization script on the desktop page.
- #26 is a usage question about where to configure post cover images, not a reproducible theme defect.

## Validation

- `git diff --check`
- `pnpm lint`
- `pnpm build`
- Local Halo readiness check at `http://localhost:8090/actuator/health/readiness`
- Static checks against generated moments template and compiled mobile CSS
